### PR TITLE
Pass a function which returns the dateFormat function to AMD `define`

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -215,7 +215,9 @@ function kindOf(val) {
 
 
   if (typeof define === 'function' && define.amd) {
-    define(dateFormat);
+    define(function () {
+      return dateFormat;
+    });
   } else if (typeof exports === 'object') {
     module.exports = dateFormat;
   } else {


### PR DESCRIPTION
When requiring an AMD module, you're given the return value of that module definition. In this case, the return value of `dateFormat` was in fact the default format of the current date and time.

We instead should be passing an anonymous function to `define`, which in turn returns the `dateFormat` function.
