### PR TITLE
Fix new Date parse for ISOString without timezones.

### DIFF
--- a/lib/dateformat.js
+++ b/lib/dateformat.js
@@ -6,6 +6,7 @@
  * Includes enhancements by Scott Trenda <scott.trenda.net>
  * and Kris Kowal <cixar.com/~kris.kowal/>
  * and Johan Heander <timezynk.com>
+ * and Sebastian Jonasson <https://github.com/sebastianjonasson>
  *
  * Accepts a date, a mask, or a date and a mask.
  * Returns a formatted version of the given date.
@@ -31,6 +32,7 @@
 
     var dateFormat = (function() {
         var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTtV])\1?|[LlopSZWNG]|"[^"]*"|'[^']*'/g;
+        var iso_wo_tz = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/;
 
         // Regexes and supporting functions are cached through closure
         return function (date, mask, utc, gmt) {
@@ -42,6 +44,27 @@
             }
 
             date = date || date === 0 ? date : new Date;
+
+            // Given an ISOString w/o timezone safari and chrome will parse new Date differently
+            // - Chrome: new Date("2019-01-01T13:00:00.000") -> Tue Jan 01 2019 13:00:00 GMT+0100 (Central European Standard Time)
+            // - Safari: new Date("2019-01-01T13:00:00.000") -> Tue Jan 01 2019 14:00:00 GMT+0100 (CET)
+            if(typeof date === 'string' && iso_wo_tz.test(date)) {
+                var parts = date.replace(/(-|T|:|\.)/g, ' ')
+                                .split(' ')
+                                .map(function(v) {
+                                    return parseInt(v, 10);
+                                });
+
+                date = new Date(
+                    parts[0],
+                    parts[1] - 1,
+                    parts[2],
+                    parts[3],
+                    parts[4],
+                    parts[5],
+                    parts[6],
+                );
+            }
 
             if(!(date instanceof Date)) {
                 date = new Date(date);


### PR DESCRIPTION
ISO strings without timezone yields different result when passed to new
Date().

Example
- Chrome: new Date("2019-01-01T13:00:00.000") -> Tue Jan 01 2019 13:00:00 GMT+0100 (Central European Standard Time)
- Safari: new Date("2019-01-01T13:00:00.000") -> Tue Jan 01 2019 14:00:00 GMT+0100 (CET)

Added manual string parsing instead.